### PR TITLE
Fix logic in subvolume split sentence

### DIFF
--- a/_posts/2020-12-16-fslayout.md
+++ b/_posts/2020-12-16-fslayout.md
@@ -70,8 +70,8 @@ the structure is application-specific and follows its own transaction
 mechanism. The usual configuration files in `/etc` need to be rolled
 back though, as some are tied to the software version installed.
 
-That lead to the separation of `/root`, `/var`, `/srv`, `/opt` and
-`/usr/local` into an extra five separate subvolumes. `/tmp` now
+That lead to the separation of the filesystem into five subvolumes, namely
+`/root`, `/var`, `/srv`, `/opt` and `/usr/local`. `/tmp` now
 usually even resides on tmpfs. That means the operating system's
 package manager cannot really install files in these directories
 anymore. Otherwise, a rollback would lead to an inconsistent package database.


### PR DESCRIPTION
if /root /var /srv /opt /var /usr/local were separated into an extra 5 volumes, we'd have 5x5=25 subvolumes.